### PR TITLE
Adding libswitch-perl as a required install

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,5 +30,5 @@
   },
   "recipes": {
   },
-  "version": "1.1.1"
+  "version": "1.2.1"
 }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'alexismidon@gmail.com'
 license          'Apache 2.0'
 description      'cloudwatch_monitoring installs the Amazon CloudWatch Monitoring Scripts for Linux - custom metrics that reports memory, swap, and disk space utilization metrics.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version "1.2.0"
+version "1.2.1"
 
 %w{ ubuntu debian redhat centos}.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,7 +41,7 @@ case node[:platform_family]
 
   when 'debian'
 
-    %w{unzip libwww-perl libcrypt-ssleay-perl}.each do |p|
+    %w{unzip libwww-perl libcrypt-ssleay-perl libswitch-perl}.each do |p|
       package p do
         action :install
       end


### PR DESCRIPTION
libswitch-perl is now required, added it to the list of packages installed for ubuntu