### PR TITLE
Update CloudWatchMonitoringScripts to version 1.2.1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,8 +3,8 @@
 default[:cw_mon][:user]              = "cw_monitoring"
 default[:cw_mon][:group]             = "cw_monitoring"
 default[:cw_mon][:home_dir]          = "/home/#{node[:cw_mon][:user]}"
-default[:cw_mon][:version]           = "1.1.0"
-default[:cw_mon][:release_url]       = "http://ec2-downloads.s3.amazonaws.com/cloudwatch-samples/CloudWatchMonitoringScripts-v1.1.0.zip"
+default[:cw_mon][:version]           = "1.2.1"
+default[:cw_mon][:release_url]       = "http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.1.zip"
 
 
 default[:cw_mon][:aws_users_databag] = "aws_users"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,8 +40,7 @@ case node[:platform_family]
     end
 
   when 'debian'
-
-    %w{unzip libwww-perl libcrypt-ssleay-perl}.each do |p|
+    %w{unzip libwww-perl libdatetime-perl}.each do |p|
       package p do
         action :install
       end


### PR DESCRIPTION
Update Ubuntu packages to install.

For details, see http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/mon-scripts.html#mon-scripts-getstarted