### PR TITLE
Get IAM roles using imds_v2

### DIFF
--- a/libraries/iam_role.rb
+++ b/libraries/iam_role.rb
@@ -2,8 +2,25 @@
 
 module IAM
   def self.role
-    require 'open-uri'
-    instance_role = open("http://169.254.169.254/latest/meta-data/iam/security-credentials/").readlines.first rescue nil
-    instance_role
+    require 'net/http'
+    require 'uri'
+
+    uri = URI('http://169.254.169.254/latest/api/token/')
+    req = Net::HTTP::Put.new(uri)
+    req['X-aws-ec2-metadata-token-ttl-seconds'] = '60'
+    res = Net::HTTP.start(uri.hostname, uri.port) {|http|
+      http.request(req)
+    }
+    token = res&.body
+
+    return unless token
+
+    uri = URI('http://169.254.169.254/latest/meta-data/iam/security-credentials/')
+    req = Net::HTTP::Get.new(uri)
+    req['X-aws-ec2-metadata-token'] = token
+    res = Net::HTTP.start(uri.hostname, uri.port) {|http|
+      http.request(req)
+    }
+    res&.body
   end
 end


### PR DESCRIPTION
# Use IMDSV2 for metadata service 
Quite a few security loopholes with IMDSV1 ec2 instance metadata service: https://hackerone.com/reports/508459

IMDSV2 is a quick drop-in

*more info* 
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html